### PR TITLE
Refactor to use tarball installation method

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -11,7 +11,6 @@ provisioner:
   # - directory[/var/run/httpd] (osl_nextcloud)
   # - apache2_install[default_install] (osl_nextcloud)
   deprecations_as_errors: true
-  data_bags_path: test/integration/data_bags
 
 driver:
   flavor_ref: m1.medium

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,8 +8,10 @@ source_url        'https://github.com/osuosl-cookbooks/osl-nextcloud'
 chef_version      '>= 16.0'
 version           '1.1.0'
 
+depends          'ark'
 depends          'osl-apache'
 depends          'osl-php'
 depends          'osl-repos'
+depends          'osl-selinux'
 
-supports 'centos_stream', '~> 8.0'
+supports 'almalinux', '~> 8.0'

--- a/resources/osl_nextcloud.rb
+++ b/resources/osl_nextcloud.rb
@@ -8,7 +8,7 @@ property :database_name, String, required: true
 property :database_password, String, sensitive: true, required: true
 property :database_user, String, sensitive: true, required: true
 property :nextcloud_admin_password, String, sensitive: true, required: true
-property :nextcloud_admin_user, String, sensitive: true, required: true
+property :nextcloud_admin_user, String, default: 'admin'
 property :mail_smtphost, String, default: 'smtp.osuosl.org'
 property :mail_from_address, String, default: 'noreply'
 property :mail_domain, String, required: true
@@ -36,9 +36,11 @@ action :create do
     zip
   )
   node.default['osl-apache']['mpm'] = 'event'
+  node.default['osl-apache']['behind_loadbalancer'] = true
 
   include_recipe 'osl-selinux'
   include_recipe 'osl-apache'
+  include_recipe 'osl-apache::mod_remoteip'
   include_recipe 'osl-php'
   include_recipe 'osl-repos::epel'
 

--- a/resources/osl_nextcloud.rb
+++ b/resources/osl_nextcloud.rb
@@ -1,26 +1,30 @@
 provides :osl_nextcloud
 unified_mode true
 
+property :version, String, default: '26.0.1'
+property :checksum, String
 property :database_host, String, sensitive: true, required: true
 property :database_name, String, required: true
 property :database_password, String, sensitive: true, required: true
 property :database_user, String, sensitive: true, required: true
 property :nextcloud_admin_password, String, sensitive: true, required: true
 property :nextcloud_admin_user, String, sensitive: true, required: true
+property :mail_smtphost, String, default: 'smtp.osuosl.org'
+property :mail_from_address, String, default: 'noreply'
+property :mail_domain, String, required: true
 property :server_name, String, name_property: true
-property :server_aliases, Array, default: %w(localhost)
-property :version, String, required: true
-property :redis_vals, Hash, default: { 'host' => '127.0.0.1', 'port' => '6379' }
 property :sensitive, [true, false], default: true
+property :server_aliases, Array, default: %w(localhost)
+property :max_filesize, String, default: '1G'
 
 default_action :create
 
 action :create do
-  node.default['php']['version'] = '8.0'
-  node.default['osl-php']['use_ius'] = true
-
+  node.default['php']['version'] = '8.1'
   node.default['osl-php']['php_packages'] = %w(
+    bcmath
     gd
+    gmp
     intl
     json
     mbstring
@@ -28,70 +32,163 @@ action :create do
     opcache
     pecl-apcu
     pecl-imagick
+    pecl-redis5
     zip
   )
-  node.default['php']['directives'] = {
-    'memory_limit' => '512M',
-    'post_max_size' => '65M',
-    'upload_max_filesize' => '60M',
-    'output_buffering' => false,
-  }
-  node.default['php']['fpm_package'] = 'php80u-fpm'
-  node.default['apache']['mod_fastcgi']['package'] = 'mod_fcgid'
-  node.default['osl-apache']['behind_loadbalancer'] = true
+  node.default['osl-apache']['mpm'] = 'event'
 
-  ::Chef::Resource.include Apache2::Cookbook::Helpers
-
+  include_recipe 'osl-selinux'
   include_recipe 'osl-apache'
-  include_recipe 'osl-apache::mod_php'
   include_recipe 'osl-php'
   include_recipe 'osl-repos::epel'
 
-  dnf_module "nextcloud:#{new_resource.version}"
-
-  package %w(nextcloud redis)
-
-  directory '/etc/httpd/nextcloud'
-
-  %w(
-    nextcloud-access.conf.avail
-    nextcloud-auth-any.inc
-    nextcloud-auth-local.inc
-    nextcloud-auth-none.inc
-    nextcloud-defaults.inc
-  ).each do |f|
-    cookbook_file "/etc/httpd/nextcloud/#{f}" do
-      cookbook 'osl-nextcloud'
+  %w(proxy proxy_fcgi).each do |m|
+    apache2_module m do
+      notifies :reload, 'apache2_service[osuosl]'
     end
   end
 
-  apache_app new_resource.server_name do
-    directory '/usr/share/nextcloud'
-    allow_override 'All'
-    cookbook_include 'osl-nextcloud'
-    include_config true
-    include_name 'nextcloud'
+  php_ini 'nextcloud' do
+    options(
+      'apc.enable_cli' => '1',
+      'memory_limit' => '512M',
+      'output_buffering' => false,
+      'post_max_size' => new_resource.max_filesize,
+      'upload_max_filesize' => new_resource.max_filesize
+    )
   end
+
+  php_fpm_pool 'nextcloud' do
+    listen '/var/run/nextcloud-fpm.sock'
+  end
+
+  nextcloud_dir = "/var/www/#{new_resource.server_name}"
+  nextcloud_webroot = "#{nextcloud_dir}/nextcloud"
+  nextcloud_webroot_versioned = "#{nextcloud_dir}/nextcloud-#{new_resource.version}"
+  nextcloud_data = "#{nextcloud_dir}/data"
+
+  selinux_fcontext "#{nextcloud_data}(/.*)?" do
+    secontext 'httpd_sys_rw_content_t'
+    notifies :run, 'execute[nextcloud: restorecon]'
+  end
+
+  selinux_fcontext "#{nextcloud_webroot_versioned}/config(/.*)?" do
+    secontext 'httpd_sys_rw_content_t'
+    notifies :run, 'execute[nextcloud: restorecon]'
+  end
+
+  selinux_fcontext "#{nextcloud_webroot_versioned}/apps(/.*)?" do
+    secontext 'httpd_sys_rw_content_t'
+    notifies :run, 'execute[nextcloud: restorecon]'
+  end
+
+  selinux_fcontext "#{nextcloud_webroot_versioned}/.htaccess" do
+    secontext 'httpd_sys_rw_content_t'
+    notifies :run, 'execute[nextcloud: restorecon]'
+  end
+
+  selinux_fcontext "#{nextcloud_webroot_versioned}/.user.ini" do
+    secontext 'httpd_sys_rw_content_t'
+    notifies :run, 'execute[nextcloud: restorecon]'
+  end
+
+  selinux_fcontext "#{nextcloud_webroot_versioned}/3rdparty/aws/aws-sdk-php/src/data/logs(/.*)?" do
+    secontext 'httpd_sys_rw_content_t'
+    notifies :run, 'execute[nextcloud: restorecon]'
+  end
+
+  execute 'nextcloud: restorecon' do
+    command "restorecon -R #{nextcloud_dir}"
+    action :nothing
+  end
+
+  %w(
+    httpd_can_network_connect
+    httpd_can_network_connect_db
+    httpd_can_network_memcache
+    httpd_can_sendmail
+    httpd_use_gpg
+  ).each do |b|
+    selinux_boolean b do
+      value true
+    end
+  end
+
+  directory nextcloud_dir
+
+  directory nextcloud_data do
+    owner 'apache'
+    group 'apache'
+  end
+
+  package %w(tar bzip2)
+
+  ark 'nextcloud' do
+    url "https://download.nextcloud.com/server/releases/nextcloud-#{new_resource.version}.tar.bz2"
+    prefix_root nextcloud_dir
+    prefix_home nextcloud_dir
+    version new_resource.version
+    checksum new_resource.checksum || osl_nextcloud_checksum(new_resource.version)
+    notifies :create, "remote_file[#{nextcloud_webroot}/config/config.php]", :immediately
+    notifies :run, 'execute[fix-nextcloud-owner]', :immediately
+    notifies :run, 'execute[disable-nextcloud-crontab]', :immediately
+    notifies :run, 'execute[upgrade-nextcloud]', :immediately
+  end
+
+  # Copy current config (if it exists) to webroot
+  # This is primarily needed when upgrading between versions
+  remote_file "#{nextcloud_webroot}/config/config.php" do
+    owner 'apache'
+    group 'apache'
+    mode '0640'
+    source "file://#{nextcloud_dir}/config.php"
+    only_if { ::File.exist?("#{nextcloud_dir}/config.php") }
+    sensitive true
+    action :nothing
+  end
+
+  execute 'fix-nextcloud-owner' do
+    command "chown -R apache:apache #{nextcloud_webroot}/{apps,config}"
+    action :nothing
+  end
+
+  package 'redis'
 
   service 'redis' do
     action [:enable, :start]
   end
 
-  directory '/usr/share/nextcloud/data' do
-    owner 'apache'
-    group 'apache'
+  apache_app new_resource.server_name do
+    directory nextcloud_webroot
+    allow_override 'All'
+    directory_options %w(FollowSymLinks MultiViews)
+    directive_http [
+      '<FilesMatch "\.(php|phar)$">',
+      '  SetHandler "proxy:unix:/var/run/nextcloud-fpm.sock|fcgi://localhost/"',
+      '</FilesMatch>',
+    ]
+    directory_custom_directives [
+      'Require all granted',
+      '<IfModule mod_dav.c>',
+      '  Dav off',
+      '</IfModule>',
+    ]
   end
 
-  execute 'occ-nextcloud' do
-    cwd '/usr/share/nextcloud/'
+  execute 'install-nextcloud' do
+    cwd nextcloud_webroot
     user 'apache'
     group 'apache'
-    command "php occ maintenance:install --database 'mysql' \
-      --database-name #{new_resource.database_name} \
-      --database-user #{new_resource.database_user} \
-      --database-pass #{new_resource.database_password} \
-      --admin-user #{new_resource.nextcloud_admin_user} \
-      --admin-pass #{new_resource.nextcloud_admin_password}"
+    command <<~EOC
+      php occ maintenance:install --database 'mysql' \
+        --database-name #{new_resource.database_name} \
+        --database-user #{new_resource.database_user} \
+        --database-pass #{new_resource.database_password} \
+        --admin-user #{new_resource.nextcloud_admin_user} \
+        --admin-pass #{new_resource.nextcloud_admin_password} \
+        --data-dir #{nextcloud_data}
+    EOC
+    live_stream true
     sensitive new_resource.sensitive
     only_if { can_install? }
   end
@@ -99,31 +196,105 @@ action :create do
   # Call this once
   nc_config = osl_nextcloud_config
 
+  nc_installed = nc_config['system']['installed']
   cur_trusted_domains = nc_config['system']['trusted_domains']
-  new_trusted_domains = [new_resource.server_name, new_resource.server_aliases].flatten!.sort
+  new_trusted_domains = [new_resource.server_name, new_resource.server_aliases].flatten!.sort.uniq
+
+  # Disable crontab entry while doing an upgrade
+  execute 'disable-nextcloud-crontab' do
+    command 'crontab -u apache -r'
+    action :nothing
+    only_if { nc_installed == true && ::File.exist?('/var/spool/cron/apache') }
+  end
+
+  # https://docs.nextcloud.com/server/latest/admin_manual/maintenance/upgrade.html
+  execute 'upgrade-nextcloud' do
+    cwd nextcloud_webroot
+    user 'apache'
+    group 'apache'
+    command <<~EOC
+      php occ maintenance:mode --on
+      php occ upgrade
+      php occ maintenance:mode --off
+      php occ db:add-missing-columns
+      php occ db:add-missing-indices
+      php occ db:add-missing-primary-keys
+    EOC
+    live_stream true
+    action :nothing
+    only_if { nc_installed == true }
+  end
 
   new_trusted_domains.each do |domain|
-    execute "trusted-domains-#{domain}" do
-      cwd '/usr/share/nextcloud'
+    execute "nextcloud-config: trusted-domains-#{domain}" do
+      cwd nextcloud_webroot
       user 'apache'
       command "php occ config:system:set trusted_domains #{new_resource.server_aliases.find_index(domain)} --value=#{domain}"
       not_if { cur_trusted_domains.include?(domain) }
     end
   end
 
-  execute 'redis-cache' do
-    cwd '/usr/share/nextcloud'
+  execute 'nextcloud-config: memcache' do
+    cwd nextcloud_webroot
     user 'apache'
-    command "php occ config:system:set memcache.distributed --value='\\OC\\Memcache\\Redis'"
-    not_if { nc_config['system']['memcache.distributed'] == '\\OC\\Memcache\\Redis' }
+    command 'php occ config:system:set memcache.distributed --value="\OC\Memcache\Redis" && php occ config:system:set memcache.local --value="\OC\Memcache\APCu"'
+    not_if do
+      nc_config['system']['memcache.distributed'] == '\OC\Memcache\Redis' && \
+        nc_config['system']['memcache.local'] == '\OC\Memcache\APCu'
+    end
   end
 
-  new_resource.redis_vals.each do |name, value|
-    execute "redis-#{name}" do
-      cwd '/usr/share/nextcloud'
-      user 'apache'
-      command "php occ config:system:set redis #{name} --value=#{value}"
-      not_if { nc_config['system']['redis'] }
+  execute 'nextcloud-config: redis' do
+    cwd nextcloud_webroot
+    user 'apache'
+    command <<~EOC
+      php occ config:system:set redis host --value=127.0.0.1
+      php occ config:system:set redis port --value=6379
+    EOC
+    not_if { nc_config['system']['redis'] == { 'host' => '127.0.0.1', 'port' => '6379' } }
+  end
+
+  execute 'nextcloud-config: mail' do
+    cwd nextcloud_webroot
+    user 'apache'
+    command <<~EOC
+      php occ config:system:set mail_smtpmode --value=smtp
+      php occ config:system:set mail_sendmailmode --value=smtp
+      php occ config:system:set mail_smtphost --value=#{new_resource.mail_smtphost}
+      php occ config:system:set mail_from_address --value=#{new_resource.mail_from_address}
+      php occ config:system:set mail_domain --value=#{new_resource.mail_domain}
+    EOC
+    not_if do
+      nc_config['system']['mail_smtpmode'] == 'smtp' && \
+        nc_config['system']['mail_sendmailmode'] == 'smtp' && \
+        nc_config['system']['mail_smtphost'] == new_resource.mail_smtphost && \
+        nc_config['system']['mail_from_address'] == new_resource.mail_from_address && \
+        nc_config['system']['mail_domain'] == new_resource.mail_domain
     end
+  end
+
+  execute 'nextcloud-config: phone_region' do
+    cwd nextcloud_webroot
+    user 'apache'
+    command <<~EOC
+      php occ config:system:set default_phone_region --value=us
+    EOC
+    not_if { nc_config['system']['default_phone_region'] == 'us' }
+  end
+
+  cron 'nextcloud' do
+    command "/usr/bin/php -f #{nextcloud_webroot}/cron.php"
+    user 'apache'
+    minute '*/5'
+  end
+
+  # Copy current config to top of webroot. This is used during upgrades
+  remote_file "#{nextcloud_dir}/config.php" do
+    owner 'apache'
+    group 'apache'
+    mode '0640'
+    source "file://#{nextcloud_webroot}/config/config.php"
+    sensitive true
+    only_if { nc_installed == true }
   end
 end

--- a/resources/osl_nextcloud.rb
+++ b/resources/osl_nextcloud.rb
@@ -60,8 +60,15 @@ action :create do
     )
   end
 
+  # Current size is 52MB
+  fpm_settings = osl_php_fpm_settings(52)
+
   php_fpm_pool 'nextcloud' do
     listen '/var/run/nextcloud-fpm.sock'
+    max_children fpm_settings['max_children']
+    start_servers fpm_settings['start_servers']
+    min_spare_servers fpm_settings['min_spare_servers']
+    max_spare_servers fpm_settings['max_spare_servers']
   end
 
   nextcloud_dir = "/var/www/#{new_resource.server_name}"
@@ -231,7 +238,7 @@ action :create do
     execute "nextcloud-config: trusted-domains-#{domain}" do
       cwd nextcloud_webroot
       user 'apache'
-      command "php occ config:system:set trusted_domains #{new_resource.server_aliases.find_index(domain)} --value=#{domain}"
+      command "php occ config:system:set trusted_domains #{new_trusted_domains.find_index(domain)} --value=#{domain}"
       not_if { cur_trusted_domains.include?(domain) }
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,29 +3,15 @@ require 'chefspec/berkshelf'
 
 Dir['libraries/*.rb'].each { |f| require File.expand_path(f) }
 
-CENTOS_8 = {
-  platform: 'centos',
+ALMA_8 = {
+  platform: 'almalinux',
   version: '8',
 }.freeze
 
 ALL_PLATFORMS = [
-  CENTOS_8,
+  ALMA_8,
 ].freeze
 
 RSpec.configure do |config|
   config.log_level = :warn
-end
-
-shared_context 'common_stubs' do
-  before do
-    stub_data_bag_item('nextcloud', 'credentials').and_return(
-      'id' => 'credentials',
-      'db_host' => 'localhost',
-      'db_port' => '3306',
-      'db_user' => 'nextcloud',
-      'db_passw' => 'nextcloud',
-      'db_dbname' => 'nextcloud'
-    )
-    stub_command("mysqladmin --user=root --password='' version").and_return(true)
-  end
 end

--- a/spec/unit/resources/osl_nextcloud_spec.rb
+++ b/spec/unit/resources/osl_nextcloud_spec.rb
@@ -11,27 +11,60 @@ describe 'nextcloud-test::default' do
 
       include_context 'common_stubs'
 
-      occ_config = '{"system": {
-                      "trusted_domains": [ "localhost", "nextcloud.example.com" ],
-                      "redis": {
-                        "host": "***REMOVED SENSITIVE VALUE***",
-                        "port": "6379"
-                      }
-                    }}'
+      nc = '/var/www/nextcloud.example.com'
+      nc_d = "#{nc}/data"
+      nc_wr = "#{nc}/nextcloud"
+      nc_v = "#{nc}/nextcloud-26.0.1"
+
+      occ_config =
+        '{
+          "system": {
+            "default_phone_region": "us",
+            "installed": true,
+            "memcache.distributed": "\\\OC\\\Memcache\\\Redis",
+            "memcache.local": "\\\OC\\\Memcache\\\APCu",
+            "mail_smtpmode": "smtp",
+            "mail_sendmailmode": "smtp",
+            "mail_smtphost": "smtp.osuosl.org",
+            "mail_from_address": "noreply",
+            "mail_domain": "example.com",
+            "trusted_domains": [ "localhost", "nextcloud.example.com" ],
+            "redis": {
+                "host": "127.0.0.1",
+                "port": "6379"
+              }
+            }
+          }'
       occ_config = JSON.parse(occ_config)
 
       context 'nextcloud not installed' do
         before do
           stubs_for_provider('osl_nextcloud[test]') do |provider|
-            allow(provider).to receive_shell_out('php occ config:list', { cwd: '/usr/share/nextcloud/', user: 'apache', group: 'apache' }).and_return(
+            allow(provider).to receive_shell_out(
+              'php occ config:list --private',
+              {
+                cwd: '/var/www/nextcloud.example.com/nextcloud',
+                user: 'apache',
+                group: 'apache',
+              }
+            ).and_return(
               double(stdout: '{"system": {"trusted_domains": ["localhost"]}}', exitstatus: 0)
             )
           end
-          stubs_for_resource('execute[occ-nextcloud]') do |resource|
-            allow(resource).to receive_shell_out('php occ | grep maintenance:install', { cwd: '/usr/share/nextcloud/', user: 'apache', group: 'apache' }).and_return(
+          stubs_for_resource('execute[install-nextcloud]') do |resource|
+            allow(resource).to receive_shell_out(
+              'php occ | grep maintenance:install',
+              {
+                cwd: '/var/www/nextcloud.example.com/nextcloud',
+                user: 'apache',
+                group: 'apache',
+              }
+            ).and_return(
               double(exitstatus: 0)
             )
           end
+          content = StringIO.new '6f9c6a1248d7c8af4ad473d73a42565f6adabad4531c5cfa57bc3497b2b64f48  nextcloud-26.0.1.tar.bz2'
+          allow(URI).to receive(:open).and_return(content)
         end
 
         let(:node) { runner.node }
@@ -41,23 +74,12 @@ describe 'nextcloud-test::default' do
           expect { chef_run }.to_not raise_error
         end
 
-        it do
-          expect(chef_run).to create_template('/etc/php.ini').with(
-            variables: {
-              directives: { 'post_max_size' => '65M',
-                            'memory_limit' => '512M',
-                            'upload_max_filesize' => '60M',
-                            'output_buffering' => false },
-            }
-          )
-        end
-
         describe 'included recipes' do
           %w(
             osl-apache
-            osl-apache::mod_php
             osl-php
             osl-repos::epel
+            osl-selinux
           ).each do |r|
             it do
               expect(chef_run).to include_recipe(r)
@@ -65,42 +87,237 @@ describe 'nextcloud-test::default' do
           end
         end
 
-        it { expect(chef_run).to install_package(%w(nextcloud redis)) }
-
-        it { expect(chef_run).to create_directory('/etc/httpd/nextcloud') }
-
-        %w(
-          /etc/httpd/nextcloud/nextcloud-access.conf.avail
-          /etc/httpd/nextcloud/nextcloud-auth-any.inc
-          /etc/httpd/nextcloud/nextcloud-auth-local.inc
-          /etc/httpd/nextcloud/nextcloud-auth-none.inc
-          /etc/httpd/nextcloud/nextcloud-defaults.inc
-        ).each do |f|
-          it { expect(chef_run).to create_cookbook_file(f) }
+        %w(proxy proxy_fcgi).each do |m|
+          it { expect(chef_run).to enable_apache2_module m }
+          it { expect(chef_run.apache2_module(m)).to notify('apache2_service[osuosl]').to(:reload) }
         end
 
+        it do
+          expect(chef_run).to add_php_ini('nextcloud').with(
+            options: {
+              'apc.enable_cli' => '1',
+              'memory_limit' => '512M',
+              'output_buffering' => false,
+              'post_max_size' => '1G',
+              'upload_max_filesize' => '1G',
+            }
+          )
+        end
+
+        it { expect(chef_run).to install_php_fpm_pool('nextcloud').with(listen: '/var/run/nextcloud-fpm.sock') }
+
+        it do
+          expect(chef_run).to manage_selinux_fcontext("#{nc_d}(/.*)?").with(secontext: 'httpd_sys_rw_content_t')
+        end
+
+        it do
+          expect(chef_run).to manage_selinux_fcontext("#{nc_v}/config(/.*)?").with(secontext: 'httpd_sys_rw_content_t')
+        end
+
+        it do
+          expect(chef_run).to manage_selinux_fcontext("#{nc_v}/apps(/.*)?").with(secontext: 'httpd_sys_rw_content_t')
+        end
+
+        it do
+          expect(chef_run).to manage_selinux_fcontext("#{nc_v}/.htaccess").with(secontext: 'httpd_sys_rw_content_t')
+        end
+
+        it do
+          expect(chef_run).to manage_selinux_fcontext("#{nc_v}/.user.ini").with(secontext: 'httpd_sys_rw_content_t')
+        end
+
+        it do
+          expect(chef_run).to manage_selinux_fcontext("#{nc_v}/3rdparty/aws/aws-sdk-php/src/data/logs(/.*)?").with(
+            secontext: 'httpd_sys_rw_content_t'
+          )
+        end
+
+        [
+          "#{nc_d}(/.*)?",
+          "#{nc_v}/config(/.*)?",
+          "#{nc_v}/apps(/.*)?",
+          "#{nc_v}/.htaccess",
+          "#{nc_v}/.user.ini",
+          "#{nc_v}/3rdparty/aws/aws-sdk-php/src/data/logs(/.*)?",
+        ].each do |f|
+          it { expect(chef_run.selinux_fcontext(f)).to notify('execute[nextcloud: restorecon]').to(:run) }
+        end
+
+        it do
+          expect(chef_run).to nothing_execute('nextcloud: restorecon').with(
+            command: "restorecon -R #{nc}"
+          )
+        end
+
+        %w(
+          httpd_can_network_connect
+          httpd_can_network_connect_db
+          httpd_can_network_memcache
+          httpd_can_sendmail
+          httpd_use_gpg
+        ).each do |b|
+          it { expect(chef_run).to set_selinux_boolean(b).with(value: 'on') }
+        end
+
+        it { expect(chef_run).to create_directory(nc) }
+        it { expect(chef_run).to create_directory(nc_d).with(owner: 'apache', group: 'apache') }
+        it { expect(chef_run).to install_package(%w(tar bzip2)) }
+
+        it do
+          expect(chef_run).to install_ark('nextcloud').with(
+            url: 'https://download.nextcloud.com/server/releases/nextcloud-26.0.1.tar.bz2',
+            prefix_root: nc,
+            prefix_home: nc,
+            checksum: '6f9c6a1248d7c8af4ad473d73a42565f6adabad4531c5cfa57bc3497b2b64f48'
+          )
+        end
+
+        it do
+          expect(chef_run.ark('nextcloud')).to \
+            notify("remote_file[#{nc_wr}/config/config.php]").to(:create).immediately
+        end
+
+        it { expect(chef_run.ark('nextcloud')).to notify('execute[fix-nextcloud-owner]').to(:run).immediately }
+        it { expect(chef_run.ark('nextcloud')).to notify('execute[disable-nextcloud-crontab]').to(:run).immediately }
+        it { expect(chef_run.ark('nextcloud')).to notify('execute[upgrade-nextcloud]').to(:run).immediately }
+
+        it do
+          expect(chef_run).to nothing_remote_file("#{nc_wr}/config/config.php").with(
+            owner: 'apache',
+            group: 'apache',
+            mode: '0640',
+            source: "file://#{nc}/config.php",
+            sensitive: true
+          )
+        end
+
+        it do
+          expect(chef_run).to nothing_execute('fix-nextcloud-owner').with(
+            command: "chown -R apache:apache #{nc_wr}/{apps,config}"
+          )
+        end
+
+        it { expect(chef_run).to install_package('redis') }
         it { expect(chef_run).to enable_service('redis') }
         it { expect(chef_run).to start_service('redis') }
 
-        it { expect(chef_run).to run_execute('occ-nextcloud').with(user: 'apache') }
-        it { expect(chef_run).to_not run_execute('trusted-domains-localhost') }
-        it { expect(chef_run).to run_execute('trusted-domains-nextcloud.example.com').with(user: 'apache') }
-        it { expect(chef_run).to run_execute('redis-host') }
-        it { expect(chef_run).to run_execute('redis-port') }
+        it do
+          expect(chef_run).to create_apache_app('nextcloud.example.com').with(
+            directory: nc_wr,
+            allow_override: 'All',
+            directory_options: %w(FollowSymLinks MultiViews),
+            directive_http: [
+              '<FilesMatch "\.(php|phar)$">',
+              '  SetHandler "proxy:unix:/var/run/nextcloud-fpm.sock|fcgi://localhost/"',
+              '</FilesMatch>',
+            ]
+          )
+        end
+
+        it do
+          expect(chef_run).to run_execute('install-nextcloud').with(
+            cwd: nc_wr,
+            user: 'apache',
+            group: 'apache',
+            command: "php occ maintenance:install --database 'mysql'   --database-name nextcloud   --database-user nextcloud   --database-pass nextcloud   --admin-user admin   --admin-pass unguessable   --data-dir /var/www/nextcloud.example.com/data\n",
+            live_stream: true,
+            sensitive: true
+          )
+        end
+
+        it { expect(chef_run).to nothing_execute('disable-nextcloud-crontab').with(command: 'crontab -u apache -r') }
+
+        it do
+          expect(chef_run).to nothing_execute('upgrade-nextcloud').with(
+            cwd: nc_wr,
+            user: 'apache',
+            group: 'apache',
+            command: "php occ maintenance:mode --on\nphp occ upgrade\nphp occ maintenance:mode --off\nphp occ db:add-missing-columns\nphp occ db:add-missing-indices\nphp occ db:add-missing-primary-keys\n",
+            live_stream: true
+          )
+        end
+
+        it do
+          expect(chef_run).to_not run_execute('nextcloud-config: trusted-domains-localhost')
+        end
+
+        it do
+          expect(chef_run).to run_execute('nextcloud-config: trusted-domains-nextcloud.example.com').with(
+            cwd: nc_wr,
+            user: 'apache',
+            command: 'php occ config:system:set trusted_domains 1 --value=nextcloud.example.com'
+          )
+        end
+
+        it do
+          expect(chef_run).to run_execute('nextcloud-config: memcache').with(
+            cwd: nc_wr,
+            user: 'apache',
+            command: 'php occ config:system:set memcache.distributed --value="\OC\Memcache\Redis" && php occ config:system:set memcache.local --value="\OC\Memcache\APCu"'
+          )
+        end
+
+        it do
+          expect(chef_run).to run_execute('nextcloud-config: redis').with(
+            cwd: nc_wr,
+            user: 'apache',
+            command: "php occ config:system:set redis host --value=127.0.0.1\nphp occ config:system:set redis port --value=6379\n"
+          )
+        end
+
+        it do
+          expect(chef_run).to run_execute('nextcloud-config: mail').with(
+            cwd: nc_wr,
+            user: 'apache',
+            command: "php occ config:system:set mail_smtpmode --value=smtp\nphp occ config:system:set mail_sendmailmode --value=smtp\nphp occ config:system:set mail_smtphost --value=smtp.osuosl.org\nphp occ config:system:set mail_from_address --value=noreply\nphp occ config:system:set mail_domain --value=example.com\n"
+          )
+        end
+
+        it do
+          expect(chef_run).to run_execute('nextcloud-config: phone_region').with(
+            cwd: nc_wr,
+            user: 'apache',
+            command: "php occ config:system:set default_phone_region --value=us\n"
+          )
+        end
+
+        it do
+          expect(chef_run).to create_cron('nextcloud').with(
+            command: '/usr/bin/php -f /var/www/nextcloud.example.com/nextcloud/cron.php',
+            user: 'apache',
+            minute: '*/5'
+          )
+        end
+
+        it do
+          expect(chef_run).to_not create_remote_file("#{nc}/config.php").with(
+            owner: 'apache',
+            group: 'apache',
+            mode: '0640',
+            source: "file://#{nc_wr}/config/config.php",
+            sensitive: true
+          )
+        end
       end
 
       context 'nextcloud installed' do
         before do
           allow_any_instance_of(OSLNextcloud::Cookbook::Helpers).to receive(:can_install?).and_return(false)
           allow_any_instance_of(OSLNextcloud::Cookbook::Helpers).to receive(:osl_nextcloud_config).and_return(occ_config)
+          content = StringIO.new '6f9c6a1248d7c8af4ad473d73a42565f6adabad4531c5cfa57bc3497b2b64f48  nextcloud-26.0.1.tar.bz2'
+          allow(URI).to receive(:open).and_return(content)
         end
         let(:node) { runner.node }
         cached(:chef_run) { runner.converge(described_recipe) }
+        it { expect(chef_run).to_not run_execute('install-nextcloud') }
+        it { expect(chef_run).to_not run_execute('upgrade-nextcloud') }
         it { expect(chef_run).to_not run_execute('trusted-domains-localhost') }
         it { expect(chef_run).to_not run_execute('trusted-domains-nextcloud.example.com') }
-        it { expect(chef_run).to_not run_execute('occ-nextcloud') }
-        it { expect(chef_run).to_not run_execute('redis-host') }
-        it { expect(chef_run).to_not run_execute('redis-port') }
+        it { expect(chef_run).to_not run_execute('nextcloud-config: memcache') }
+        it { expect(chef_run).to_not run_execute('nextcloud-config: redis') }
+        it { expect(chef_run).to_not run_execute('nextcloud-config: mail') }
+        it { expect(chef_run).to_not run_execute('nextcloud-config: phone_region') }
+        it { expect(chef_run).to create_remote_file("#{nc}/config.php") }
       end
     end
   end

--- a/spec/unit/resources/osl_nextcloud_spec.rb
+++ b/spec/unit/resources/osl_nextcloud_spec.rb
@@ -77,6 +77,7 @@ describe 'nextcloud-test::default' do
         describe 'included recipes' do
           %w(
             osl-apache
+            osl-apache::mod_remoteip
             osl-php
             osl-repos::epel
             osl-selinux

--- a/spec/unit/resources/osl_nextcloud_spec.rb
+++ b/spec/unit/resources/osl_nextcloud_spec.rb
@@ -105,7 +105,15 @@ describe 'nextcloud-test::default' do
           )
         end
 
-        it { expect(chef_run).to install_php_fpm_pool('nextcloud').with(listen: '/var/run/nextcloud-fpm.sock') }
+        it do
+          expect(chef_run).to install_php_fpm_pool('nextcloud').with(
+            listen: '/var/run/nextcloud-fpm.sock',
+            max_children: 4,
+            start_servers: 1,
+            min_spare_servers: 1,
+            max_spare_servers: 3
+          )
+        end
 
         it do
           expect(chef_run).to manage_selinux_fcontext("#{nc_d}(/.*)?").with(secontext: 'httpd_sys_rw_content_t')

--- a/test/cookbooks/nextcloud-test/recipes/default.rb
+++ b/test/cookbooks/nextcloud-test/recipes/default.rb
@@ -48,7 +48,6 @@ osl_nextcloud 'test' do
   database_name 'nextcloud'
   database_user 'nextcloud'
   database_password 'nextcloud'
-  nextcloud_admin_user 'admin'
   nextcloud_admin_password 'unguessable'
   mail_domain 'example.com'
   server_aliases %w(localhost nextcloud.example.com)

--- a/test/cookbooks/nextcloud-test/recipes/default.rb
+++ b/test/cookbooks/nextcloud-test/recipes/default.rb
@@ -16,34 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-node.override['percona']['version'] = '5.7'
-node.default['percona']['server']['root_password'] = 'nextcloud'
-node.default['percona']['backup']['password'] = 'nextcloud'
-
-dbcreds = data_bag_item('nextcloud', 'credentials')
-
-include_recipe 'osl-mysql::server'
-
-percona_mysql_database dbcreds['db_dbname'] do
-  password node['percona']['server']['root_password']
+osl_mysql_test 'nextcloud' do
+  username 'nextcloud'
+  password 'nextcloud'
 end
 
-percona_mysql_user dbcreds['db_user'] do
-  database_name dbcreds['db_dbname']
-  password dbcreds['db_passw']
-  host dbcreds['db_host']
-  ctrl_password node['percona']['server']['root_password']
-  action [:create, :grant]
-end
-
-service 'apache2' do
-  service_name lazy { apache_platform_service_name }
-  supports restart: true, status: true, reload: true, enable: true
-  action :nothing
-end
-
-osl_nextcloud 'test' do
-  server_name 'nextcloud.example.com'
+osl_nextcloud 'nextcloud.example.com' do
   database_host 'localhost'
   database_name 'nextcloud'
   database_user 'nextcloud'

--- a/test/cookbooks/nextcloud-test/recipes/default.rb
+++ b/test/cookbooks/nextcloud-test/recipes/default.rb
@@ -43,7 +43,6 @@ service 'apache2' do
 end
 
 osl_nextcloud 'test' do
-  version '23'
   server_name 'nextcloud.example.com'
   database_host 'localhost'
   database_name 'nextcloud'
@@ -51,5 +50,6 @@ osl_nextcloud 'test' do
   database_password 'nextcloud'
   nextcloud_admin_user 'admin'
   nextcloud_admin_password 'unguessable'
+  mail_domain 'example.com'
   server_aliases %w(localhost nextcloud.example.com)
 end

--- a/test/integration/data_bags/nextcloud/credentials.json
+++ b/test/integration/data_bags/nextcloud/credentials.json
@@ -1,8 +1,0 @@
-{
-  "id": "credentials",
-  "db_host": "localhost",
-  "db_port": "3306",
-  "db_user": "nextcloud",
-  "db_passw": "nextcloud",
-  "db_dbname": "nextcloud"
-}

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -86,6 +86,13 @@ control 'osl_nextcloud' do
     its('stdout') { should match /^port: 6379$/ }
   end
 
+  describe file('/etc/php-fpm.d/nextcloud.conf') do
+    its('content') { should match /^pm.max_children = 44$/ }
+    its('content') { should match /^pm.start_servers = 11$/ }
+    its('content') { should match /^pm.min_spare_servers = 11$/ }
+    its('content') { should match /^pm.max_spare_servers = 33$/ }
+  end
+
   describe http('http://localhost') do
     its('status') { should eq 200 }
     its('headers.Content-Type') { should match 'text/html' }


### PR DESCRIPTION
Unfortunately the EPEL modular repos have been deprecated and we need to refactor this to use the tarball installation method. Some other notable changes:

- Automatically pull checksum from upstream so we don't have to manually set it
- Properly set email settings and create new properties to manage those
- Upgrade to PHP 8.1
- Includ additional missing php packages
- Switch to using MPM event (upstream recommended)
- Switch to using php-fpm from mod_php
- Add SELinux support
- Add support for automatic upgrades
- Add cron job
- Set other settings that are required

Signed-off-by: Lance Albertson <lance@osuosl.org>
