### PR TITLE
Automatically install latest patch release

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,3 @@
-AllCops:
-  TargetChefVersion: 16.latest
 Chef/Modernize/FoodcriticComments:
   Enabled: true
 Chef/Style/CopyrightCommentFormat:

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -2,8 +2,25 @@ module OSLNextcloud
   module Cookbook
     module Helpers
       require 'json'
-      require 'uri'
+      require 'net/http'
       require 'open-uri'
+      require 'uri'
+
+      # Get latest version of nextcloud from Github
+      def osl_nextcloud_latest_version(version)
+        releases = []
+        uri = URI('https://api.github.com/repos/nextcloud/server/releases')
+        response = JSON.parse(Net::HTTP.get(uri))
+        response.each do |rel|
+          # Match version given and exclude all release candidate and beta releases
+          if rel['name'].match?(/^v#{version}/) && !rel['name'].match?(/rc|beta/)
+            # Remove leading 'v' from name
+            releases << rel['name'][1..-1]
+          end
+        end
+        # First one should be latest
+        releases[0]
+      end
 
       # Get sha256sum from nextcloud website
       def osl_nextcloud_checksum(version)

--- a/spec/unit/resources/osl_nextcloud_spec.rb
+++ b/spec/unit/resources/osl_nextcloud_spec.rb
@@ -9,12 +9,13 @@ describe 'nextcloud-test::default' do
         )
       end
 
-      nc_version = '28.0.2'
+      nc_version = '28.0.0'
       nc_checksum = '801c9ae912cf6264be72c141e418d3d87d4e671c7a9dd643008f5d7d6991ea2e'
       nc = '/var/www/nextcloud.example.com'
       nc_d = "#{nc}/data"
       nc_wr = "#{nc}/nextcloud"
       nc_v = "#{nc}/nextcloud-#{nc_version}"
+      github_releases = [{ name: 'v28.0.0' }, { name: 'v27.0.0' }]
 
       occ_config =
         '{
@@ -67,6 +68,7 @@ describe 'nextcloud-test::default' do
 
           content = StringIO.new "#{nc_checksum}  nextcloud-#{nc_version}.tar.bz2"
           allow(URI).to receive(:open).and_return(content)
+          allow(Net::HTTP).to receive(:get).and_return(github_releases.to_json)
         end
 
         let(:node) { runner.node }
@@ -317,6 +319,7 @@ describe 'nextcloud-test::default' do
           allow_any_instance_of(OSLNextcloud::Cookbook::Helpers).to receive(:osl_nextcloud_config).and_return(occ_config)
           content = StringIO.new "#{nc_checksum}  nextcloud-#{nc_version}.tar.bz2"
           allow(URI).to receive(:open).and_return(content)
+          allow(Net::HTTP).to receive(:get).and_return(github_releases.to_json)
         end
 
         let(:node) { runner.node }

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -68,7 +68,7 @@ control 'osl_nextcloud' do
   describe command('sudo -u apache php /var/www/nextcloud.example.com/nextcloud/occ status') do
     its('exit_status') { should eq 0 }
     its('stdout') { should match /installed: true/ }
-    its('stdout') { should match /versionstring: 28.0.2/ }
+    its('stdout') { should match /versionstring: 28.[0-9]+.[0-9]+/ }
   end
 
   describe command('sudo -u apache php /var/www/nextcloud.example.com/nextcloud/occ check') do


### PR DESCRIPTION
This uses the Github API to check the releases and find the latest release
included given a version given. In theory, we can still give a full semver but
for now we'll just set this to the latest major version which is 28.

Signed-off-by: Lance Albertson <lance@osuosl.org>
