### PR TITLE
Add properties to install/disable NextCloud Apps

### DIFF
--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -3,7 +3,7 @@ driver:
   name: dokken
   privileged: true  # because Docker and SystemD/Upstart
   chef_image: cincproject/cinc
-  chef_version: <%= ENV['CHEF_VERSION'] || '17' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || '18' %>
   pull_chef_image: false
   pull_platform_image: false
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -11,7 +11,7 @@ transport:
 provisioner:
   name: chef_infra
   product_name: cinc
-  product_version: '17'
+  product_version: '18'
   enforce_idempotency: true
   multiple_converge: 3
   # Three runs are required due to the following resources not being idempotent:

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -55,6 +55,38 @@ module OSLNextcloud
         end
         JSON.parse(cmd.stdout)
       end
+
+      # Return parsed output of current Nextcloud apps
+      def osl_nextcloud_apps
+        cmd = shell_out(
+          'php occ app:list --output json',
+          cwd: "/var/www/#{new_resource.server_name}/nextcloud",
+          user: 'apache',
+          group: 'apache'
+        )
+        if cmd.exitstatus != 0
+          Chef::Log.fatal('Failed executing: php occ app:list')
+          Chef::Log.fatal(cmd.stderr)
+        end
+        JSON.parse(cmd.stdout)
+      end
+
+      def osl_nextcloud_php_packages
+        %w(
+          bcmath
+          gd
+          gmp
+          intl
+          json
+          mbstring
+          mysqlnd
+          opcache
+          pecl-apcu
+          pecl-imagick
+          pecl-redis5
+          zip
+        )
+      end
     end
   end
 end

--- a/test/cookbooks/nextcloud-test/recipes/default.rb
+++ b/test/cookbooks/nextcloud-test/recipes/default.rb
@@ -22,11 +22,14 @@ osl_mysql_test 'nextcloud' do
 end
 
 osl_nextcloud 'nextcloud.example.com' do
+  apps %w(forms user_ldap)
+  apps_disable %w(weather_status)
   database_host 'localhost'
   database_name 'nextcloud'
   database_user 'nextcloud'
   database_password 'nextcloud'
   nextcloud_admin_password 'unguessable'
   mail_domain 'example.com'
+  php_packages %w(ldap)
   server_aliases %w(localhost nextcloud.example.com)
 end


### PR DESCRIPTION
This allows us to install any NextCloud applications from their webstore
automatically. This will also allow us to disable applications we don't want
enabled.

In addition, add ability to install additional php packages that might be
required for apps (i.e. ldap).

Other fixes:

- Update to testing on Cinc 18
- Switch to using json InSpec resource to test status more easily

Signed-off-by: Lance Albertson <lance@osuosl.org>
