### PR TITLE
Fix URL that shows up in activity notifications

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -102,7 +102,7 @@ module OSLNextcloud
             mysqlnd
             opcache
             pecl-apcu
-            pecl-imagick
+            pecl-imagick-im7
             pecl-redis6
             zip
           )

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -84,7 +84,6 @@ module OSLNextcloud
             gd
             gmp
             intl
-            json
             mbstring
             mysqlnd
             opcache
@@ -99,7 +98,6 @@ module OSLNextcloud
             gd
             gmp
             intl
-            json
             mbstring
             mysqlnd
             opcache

--- a/resources/osl_nextcloud.rb
+++ b/resources/osl_nextcloud.rb
@@ -318,9 +318,9 @@ action :create do
     cwd nextcloud_webroot
     user 'apache'
     command <<~EOC
-      php occ config:system:set overwrite.cli.url --value='nextcloud.example.com'
+      php occ config:system:set overwrite.cli.url --value=#{new_resource.server_name}
     EOC
-    not_if { nc_config['system']['overwrite.cli.url'] == 'nextcloud.example.com' }
+    not_if { nc_config['system']['overwrite.cli.url'] == new_resource.server_name }
   end if download_successful
 
   new_resource.apps.each do |app|

--- a/resources/osl_nextcloud.rb
+++ b/resources/osl_nextcloud.rb
@@ -313,6 +313,16 @@ action :create do
     not_if { nc_config['system']['default_phone_region'] == 'us' }
   end if download_successful
 
+  # This fixes the url in activity notifications; see Issue #24.
+  execute 'nextcloud-config: overwrite.cli.url' do
+    cwd nextcloud_webroot
+    user 'apache'
+    command <<~EOC
+      php occ config:system:set overwrite.cli.url --value='nextcloud.example.com'
+    EOC
+    not_if { nc_config['system']['overwrite.cli.url'] == 'nextcloud.example.com' }
+  end if download_successful
+
   new_resource.apps.each do |app|
     execute "nextcloud-app: install and enable #{app}" do
       cwd nextcloud_webroot

--- a/spec/unit/resources/osl_nextcloud_spec.rb
+++ b/spec/unit/resources/osl_nextcloud_spec.rb
@@ -151,7 +151,7 @@ describe 'nextcloud-test::default' do
                 mysqlnd
                 opcache
                 pecl-apcu
-                pecl-imagick
+                pecl-imagick-im7
                 pecl-redis6
                 zip
               )

--- a/spec/unit/resources/osl_nextcloud_spec.rb
+++ b/spec/unit/resources/osl_nextcloud_spec.rb
@@ -29,6 +29,7 @@ describe 'nextcloud-test::default' do
             "mail_smtphost": "smtp.osuosl.org",
             "mail_from_address": "noreply",
             "mail_domain": "example.com",
+            "overwrite.cli.url": "nextcloud.example.com",
             "trusted_domains": [ "localhost", "nextcloud.example.com" ],
             "redis": {
                 "host": "127.0.0.1",
@@ -370,6 +371,14 @@ describe 'nextcloud-test::default' do
         end
 
         it do
+          is_expected.to run_execute('nextcloud-config: overwrite.cli.url').with(
+            cwd: nc_wr,
+            user: 'apache',
+            command: "php occ config:system:set overwrite.cli.url --value='nextcloud.example.com'\n"
+          )
+        end
+
+        it do
           is_expected.to create_cron('nextcloud').with(
             command: '/usr/bin/php -f /var/www/nextcloud.example.com/nextcloud/cron.php',
             user: 'apache',
@@ -426,6 +435,7 @@ describe 'nextcloud-test::default' do
         it { is_expected.to_not run_execute('nextcloud-config: redis') }
         it { is_expected.to_not run_execute('nextcloud-config: mail') }
         it { is_expected.to_not run_execute('nextcloud-config: phone_region') }
+        it { is_expected.to_not run_execute('nextcloud-config: overwrite.cli.url') }
         it { is_expected.to_not run_execute('nextcloud-app: install and enable forms') }
         it { is_expected.to_not run_execute('nextcloud-app: disable weather_status') }
         it { is_expected.to create_remote_file("#{nc}/config.php") }

--- a/spec/unit/resources/osl_nextcloud_spec.rb
+++ b/spec/unit/resources/osl_nextcloud_spec.rb
@@ -131,7 +131,6 @@ describe 'nextcloud-test::default' do
                 gmp
                 imagick
                 intl
-                json
                 ldap
                 mbstring
                 mysqlnd
@@ -146,7 +145,6 @@ describe 'nextcloud-test::default' do
                 gd
                 gmp
                 intl
-                json
                 ldap
                 mbstring
                 mysqlnd

--- a/spec/unit/resources/osl_nextcloud_spec.rb
+++ b/spec/unit/resources/osl_nextcloud_spec.rb
@@ -374,7 +374,7 @@ describe 'nextcloud-test::default' do
           is_expected.to run_execute('nextcloud-config: overwrite.cli.url').with(
             cwd: nc_wr,
             user: 'apache',
-            command: "php occ config:system:set overwrite.cli.url --value='nextcloud.example.com'\n"
+            command: "php occ config:system:set overwrite.cli.url --value=nextcloud.example.com\n"
           )
         end
 

--- a/test/cookbooks/nextcloud-test/recipes/default.rb
+++ b/test/cookbooks/nextcloud-test/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: osl-nextcloud
 # Recipe:: default
 #
-# Copyright:: 2022-2024, Oregon State University
+# Copyright:: 2022-2025, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Set `overwrite.cli.url` to server name instead of localhost
- Remove `php-json` from package list, since it's built in and enabled by default now