### PR TITLE
Persist user-installed apps across Nextcloud upgrades

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -59,9 +59,11 @@ module OSLNextcloud
       end
 
       # Return parsed output of current Nextcloud configuration
+      # --no-warnings suppresses Symfony Console pre-command banners (e.g. app/upgrade
+      # notices) that would otherwise prepend non-JSON text and break JSON.parse.
       def osl_nextcloud_config
         cmd = shell_out(
-          'php occ config:list --private',
+          'php occ --no-warnings config:list --private',
           cwd: "/var/www/#{new_resource.server_name}/nextcloud",
           user: 'apache',
           group: 'apache'
@@ -76,7 +78,7 @@ module OSLNextcloud
       # Return parsed output of current Nextcloud apps
       def osl_nextcloud_apps
         cmd = shell_out(
-          'php occ app:list --output json',
+          'php occ --no-warnings app:list --output json',
           cwd: "/var/www/#{new_resource.server_name}/nextcloud",
           user: 'apache',
           group: 'apache'

--- a/resources/osl_nextcloud.rb
+++ b/resources/osl_nextcloud.rb
@@ -96,6 +96,11 @@ action :create do
     notifies :run, 'execute[nextcloud: restorecon]'
   end
 
+  selinux_fcontext "#{nextcloud_dir}/custom_apps(/.*)?" do
+    secontext 'httpd_sys_rw_content_t'
+    notifies :run, 'execute[nextcloud: restorecon]'
+  end
+
   selinux_fcontext "#{nextcloud_webroot_versioned}/.htaccess" do
     secontext 'httpd_sys_rw_content_t'
     notifies :run, 'execute[nextcloud: restorecon]'
@@ -135,6 +140,11 @@ action :create do
     group 'apache'
   end
 
+  directory "#{nextcloud_dir}/custom_apps" do
+    owner 'apache'
+    group 'apache'
+  end
+
   package %w(tar bzip2)
 
   ruby_block 'ark_notifies' do
@@ -145,6 +155,8 @@ action :create do
     notifies :run, 'execute[fix-nextcloud-owner]', :immediately
     notifies :run, 'execute[disable-nextcloud-crontab]', :immediately
     notifies :run, 'execute[systemctl restart php-fpm]', :immediately
+    notifies :create, "link[#{nextcloud_webroot_versioned}/custom_apps]", :immediately
+    notifies :create, "file[#{nextcloud_webroot}/config/apps_paths.config.php]", :immediately
     notifies :run, 'execute[upgrade-nextcloud]', :immediately
     action :nothing
     only_if { download_successful }
@@ -177,8 +189,48 @@ action :create do
   end
 
   execute 'fix-nextcloud-owner' do
-    command "chown -R apache:apache #{nextcloud_webroot}/{apps,config}"
+    command "chown -R apache:apache #{nextcloud_dir}/custom_apps #{nextcloud_webroot}/{apps,config}"
     action :nothing
+  end
+
+  # Symlink the persistent custom_apps dir into the versioned Nextcloud directory so
+  # Apache can serve app assets and occ sees both app paths on every version.
+  link "#{nextcloud_webroot_versioned}/custom_apps" do
+    to "#{nextcloud_dir}/custom_apps"
+    only_if { ::Dir.exist?(nextcloud_webroot_versioned) }
+  end
+
+  # Write apps_paths as a standalone config file rather than via `occ config:system:set
+  # apps_paths 0 path` etc. The positional-key form leaves apps_paths in an invalid
+  # intermediate state between calls (only `path` set, no `url`/`writable`), which makes
+  # Nextcloud print "apps directory not found!" on stdout and silently break every
+  # subsequent occ command. Nextcloud loads all *.config.php files in config/ and merges
+  # them via array_replace_recursive, so a complete config here is applied atomically.
+  file "#{nextcloud_webroot}/config/apps_paths.config.php" do
+    owner 'apache'
+    group 'apache'
+    mode '0640'
+    content <<~PHP
+      <?php
+      $CONFIG = array (
+        'apps_paths' =>
+        array (
+          0 =>
+          array (
+            'path' => '#{nextcloud_webroot}/apps',
+            'url' => '/apps',
+            'writable' => false,
+          ),
+          1 =>
+          array (
+            'path' => '#{nextcloud_dir}/custom_apps',
+            'url' => '/custom_apps',
+            'writable' => true,
+          ),
+        ),
+      );
+    PHP
+    only_if { ::Dir.exist?("#{nextcloud_webroot}/config") }
   end
 
   package osl_redis_pkg
@@ -355,6 +407,35 @@ action :create do
       php occ config:system:set maintenance_window_start --type=integer --value=#{new_resource.maintenance_window_start}
     EOC
     not_if { nc_config['system']['maintenance_window_start'] == new_resource.maintenance_window_start }
+  end if download_successful
+
+  # One-time migration: move any user-installed (non-shipped) apps out of the versioned
+  # apps/ directory into the persistent custom_apps/ directory so future upgrades don't
+  # blow them away. Shipped apps (bundled in the tarball) are identified by
+  # <shipped>true</shipped> in their appinfo/info.xml and stay in apps/.
+  execute 'nextcloud-migrate-apps-to-custom' do
+    cwd nextcloud_webroot
+    user 'apache'
+    group 'apache'
+    command <<~EOC
+      for dir in #{nextcloud_webroot}/apps/*/; do
+        [ -d "$dir" ] || continue
+        app=$(basename "$dir")
+        [ -f "$dir/appinfo/info.xml" ] || continue
+        grep -q '<shipped>true</shipped>' "$dir/appinfo/info.xml" && continue
+        [ -d "#{nextcloud_dir}/custom_apps/$app" ] && continue
+        mv "$dir" "#{nextcloud_dir}/custom_apps/$app"
+      done
+    EOC
+    not_if do
+      Dir.glob("#{nextcloud_webroot}/apps/*/").none? do |app_dir|
+        info_xml = ::File.join(app_dir, 'appinfo', 'info.xml')
+        ::File.exist?(info_xml) &&
+          !::File.read(info_xml).include?('<shipped>true</shipped>') &&
+          !::File.exist?(::File.join("#{nextcloud_dir}/custom_apps", ::File.basename(app_dir.chomp('/'))))
+      end
+    end
+    only_if { nc_installed == true }
   end if download_successful
 
   new_resource.apps.each do |app|

--- a/spec/unit/resources/osl_nextcloud_spec.rb
+++ b/spec/unit/resources/osl_nextcloud_spec.rb
@@ -67,7 +67,7 @@ describe 'nextcloud-test::default' do
         before do
           stubs_for_provider('osl_nextcloud[nextcloud.example.com]') do |provider|
             allow(provider).to receive_shell_out(
-              'php occ config:list --private',
+              'php occ --no-warnings config:list --private',
               {
                 cwd: '/var/www/nextcloud.example.com/nextcloud',
                 user: 'apache',
@@ -77,7 +77,7 @@ describe 'nextcloud-test::default' do
               double(stdout: '{"system": {"trusted_domains": ["localhost"]}}', exitstatus: 0)
             )
             allow(provider).to receive_shell_out(
-              'php occ app:list --output json',
+              'php occ --no-warnings app:list --output json',
               {
                 cwd: '/var/www/nextcloud.example.com/nextcloud',
                 user: 'apache',
@@ -106,6 +106,8 @@ describe 'nextcloud-test::default' do
           allow(Net::HTTP).to receive(:get).and_return(github_releases.to_json)
           allow(Dir).to receive(:exist?).and_call_original
           allow(Dir).to receive(:exist?).with(nc_d).and_return(true)
+          allow(Dir).to receive(:exist?).with(nc_v).and_return(true)
+          allow(Dir).to receive(:exist?).with("#{nc_wr}/config").and_return(true)
           allow(Dir).to receive(:entries).and_call_original
           allow(Dir).to receive(:entries).with(nc_d).and_return(['.', '..', 'appdata_xyz123'])
         end
@@ -229,6 +231,10 @@ describe 'nextcloud-test::default' do
           )
         end
 
+        it do
+          is_expected.to manage_selinux_fcontext("#{nc}/custom_apps(/.*)?").with(secontext: 'httpd_sys_rw_content_t')
+        end
+
         [
           "#{nc_d}(/.*)?",
           "#{nc_v}/config(/.*)?",
@@ -236,6 +242,7 @@ describe 'nextcloud-test::default' do
           "#{nc_v}/.htaccess",
           "#{nc_v}/.user.ini",
           "#{nc_v}/3rdparty/aws/aws-sdk-php/src/data/logs(/.*)?",
+          "#{nc}/custom_apps(/.*)?",
         ].each do |f|
           it { expect(chef_run.selinux_fcontext(f)).to notify('execute[nextcloud: restorecon]').to(:run) }
         end
@@ -258,6 +265,7 @@ describe 'nextcloud-test::default' do
 
         it { is_expected.to create_directory(nc) }
         it { is_expected.to create_directory(nc_d).with(owner: 'apache', group: 'apache') }
+        it { is_expected.to create_directory("#{nc}/custom_apps").with(owner: 'apache', group: 'apache') }
         it { is_expected.to install_package(%w(tar bzip2)) }
         it { is_expected.to nothing_ruby_block 'ark_notifies' }
 
@@ -280,6 +288,8 @@ describe 'nextcloud-test::default' do
         it { expect(chef_run.ruby_block('ark_notifies')).to notify('execute[fix-nextcloud-owner]').to(:run).immediately }
         it { expect(chef_run.ruby_block('ark_notifies')).to notify('execute[disable-nextcloud-crontab]').to(:run).immediately }
         it { expect(chef_run.ruby_block('ark_notifies')).to notify('execute[systemctl restart php-fpm]').to(:run).immediately }
+        it { expect(chef_run.ruby_block('ark_notifies')).to notify("link[#{nc_v}/custom_apps]").to(:create).immediately }
+        it { expect(chef_run.ruby_block('ark_notifies')).to notify("file[#{nc_wr}/config/apps_paths.config.php]").to(:create).immediately }
         it { expect(chef_run.ruby_block('ark_notifies')).to notify('execute[upgrade-nextcloud]').to(:run).immediately }
 
         it do
@@ -294,9 +304,11 @@ describe 'nextcloud-test::default' do
 
         it do
           is_expected.to nothing_execute('fix-nextcloud-owner').with(
-            command: "chown -R apache:apache #{nc_wr}/{apps,config}"
+            command: "chown -R apache:apache #{nc}/custom_apps #{nc_wr}/{apps,config}"
           )
         end
+
+        it { is_expected.to create_link("#{nc_v}/custom_apps").with(to: "#{nc}/custom_apps") }
 
         redis_pkg = platform[:version].to_i >= 10 ? 'valkey' : 'redis'
 
@@ -413,6 +425,25 @@ describe 'nextcloud-test::default' do
         end
 
         it do
+          is_expected.to create_file("#{nc_wr}/config/apps_paths.config.php").with(
+            owner: 'apache',
+            group: 'apache',
+            mode: '0640'
+          )
+        end
+
+        it do
+          expect(chef_run.file("#{nc_wr}/config/apps_paths.config.php").content).to include("'path' => '#{nc_wr}/apps'")
+          expect(chef_run.file("#{nc_wr}/config/apps_paths.config.php").content).to include("'path' => '#{nc}/custom_apps'")
+          expect(chef_run.file("#{nc_wr}/config/apps_paths.config.php").content).to include("'url' => '/apps'")
+          expect(chef_run.file("#{nc_wr}/config/apps_paths.config.php").content).to include("'url' => '/custom_apps'")
+          expect(chef_run.file("#{nc_wr}/config/apps_paths.config.php").content).to include("'writable' => false")
+          expect(chef_run.file("#{nc_wr}/config/apps_paths.config.php").content).to include("'writable' => true")
+        end
+
+        it { is_expected.to_not run_execute('nextcloud-migrate-apps-to-custom') }
+
+        it do
           is_expected.to create_cron('nextcloud').with(
             command: '/usr/bin/php -f /var/www/nextcloud.example.com/nextcloud/cron.php',
             user: 'apache',
@@ -460,8 +491,12 @@ describe 'nextcloud-test::default' do
           allow(Net::HTTP).to receive(:get).and_return(github_releases.to_json)
           allow(Dir).to receive(:exist?).and_call_original
           allow(Dir).to receive(:exist?).with(nc_d).and_return(true)
+          allow(Dir).to receive(:exist?).with(nc_v).and_return(true)
+          allow(Dir).to receive(:exist?).with("#{nc_wr}/config").and_return(true)
           allow(Dir).to receive(:entries).and_call_original
           allow(Dir).to receive(:entries).with(nc_d).and_return(['.', '..', 'appdata_xyz123'])
+          allow(Dir).to receive(:glob).and_call_original
+          allow(Dir).to receive(:glob).with("#{nc_wr}/apps/*/").and_return([])
         end
 
         let(:node) { runner.node }
@@ -477,6 +512,8 @@ describe 'nextcloud-test::default' do
         it { is_expected.to_not run_execute('nextcloud-config: phone_region') }
         it { is_expected.to_not run_execute('nextcloud-config: overwrite.cli.url') }
         it { is_expected.to_not run_execute('nextcloud-config: maintenance_window_start') }
+        it { is_expected.to_not run_execute('nextcloud-migrate-apps-to-custom') }
+        it { is_expected.to create_file("#{nc_wr}/config/apps_paths.config.php").with(owner: 'apache', group: 'apache', mode: '0640') }
         it { is_expected.to_not run_execute('nextcloud-app: install and enable forms') }
         it { is_expected.to_not run_execute('nextcloud-app: disable weather_status') }
         it { is_expected.to create_remote_file("#{nc}/config.php") }

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -60,6 +60,23 @@ control 'osl_nextcloud' do
     its('group') { should eq 'apache' }
   end
 
+  describe directory '/var/www/nextcloud.example.com/custom_apps' do
+    it { should exist }
+    its('owner') { should eq 'apache' }
+    its('group') { should eq 'apache' }
+  end
+
+  # custom_apps must be reachable through the versioned-dir symlink so Apache can serve app assets
+  describe directory '/var/www/nextcloud.example.com/nextcloud/custom_apps' do
+    it { should exist }
+  end
+
+  describe command occ('config:system:get --output json apps_paths') do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match %r{nextcloud\.example\.com\\/nextcloud\\/apps} }
+    its('stdout') { should match %r{nextcloud\.example\.com\\/custom_apps} }
+  end
+
   describe file '/var/www/nextcloud.example.com/nextcloud/config/config.php' do
     it { should exist }
     its('mode') { should cmp '0640' }


### PR DESCRIPTION
The ark resource extracts each Nextcloud release into a fresh versioned
directory, which wiped out apps installed from the App Store (e.g. Calendar,
Contacts) on every upgrade. Add a persistent custom_apps/ directory outside the
versioned tree, symlink it into the versioned webroot, and configure apps_paths
so Nextcloud installs new apps there. Migrate any non-bundled apps still living
in apps/ over to custom_apps/ on first run.

apps_paths is now written via a config.php drop-in (apps_paths.config.php)
rather than positional `occ config:system:set` calls. The positional form left
apps_paths in an invalid intermediate state after the first key was set, which
caused Nextcloud to silently refuse all subsequent occ commands.

Also pass --no-warnings to the occ JSON-parsing helpers so Symfony Console
pre-command banners don't pollute stdout and break JSON.parse.

Fixes #31

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
