### PR TITLE
Re-run db:add-missing-* after app state changes

### DIFF
--- a/resources/osl_nextcloud.rb
+++ b/resources/osl_nextcloud.rb
@@ -303,6 +303,13 @@ action :create do
   end
 
   # https://docs.nextcloud.com/server/latest/admin_manual/maintenance/upgrade.html
+  # app:update --all pulls fresh releases for every installed app, including ones not
+  # listed in new_resource.apps. A major Nextcloud bump disables any app whose
+  # info.xml hasn't been updated to declare compatibility yet; this update pass gives
+  # those apps a chance to come back online before the next chef-client run.
+  # `occ upgrade` toggles maintenance mode off when it finishes, so re-enable it before
+  # app:update / repair run — otherwise users hit half-updated apps and an in-progress
+  # consistency repair.
   execute 'upgrade-nextcloud' do
     cwd nextcloud_webroot
     user 'apache'
@@ -310,14 +317,14 @@ action :create do
     command <<~EOC
       php occ maintenance:mode --on
       php occ upgrade
-      php occ maintenance:mode --off
-      php occ db:add-missing-columns
-      php occ db:add-missing-indices
-      php occ db:add-missing-primary-keys
+      php occ maintenance:mode --on
+      php occ app:update --all
       php occ maintenance:repair --include-expensive
+      php occ maintenance:mode --off
     EOC
     live_stream true
     action :nothing
+    notifies :run, 'execute[nextcloud-db-add-missing]', :delayed
     only_if { download_successful }
     only_if { nc_installed == true }
   end
@@ -446,6 +453,7 @@ action :create do
         php occ app:install -n #{app}
         php occ app:enable -n #{app}
       EOC
+      notifies :run, 'execute[nextcloud-db-add-missing]', :delayed
       only_if { nc_apps['enabled'][app].nil? }
     end
   end if download_successful
@@ -459,6 +467,23 @@ action :create do
       EOC
       only_if { nc_apps['disabled'][app].nil? }
     end
+  end if download_successful
+
+  # Notified by upgrade-nextcloud and by per-app install/enable executes so missing
+  # schema gets backfilled whenever an app's state changes — including the case where
+  # an app disabled during a major-version bump is re-enabled on a later converge once
+  # a compatible release has shipped.
+  execute 'nextcloud-db-add-missing' do
+    cwd nextcloud_webroot
+    user 'apache'
+    group 'apache'
+    command <<~EOC
+      php occ db:add-missing-columns
+      php occ db:add-missing-indices
+      php occ db:add-missing-primary-keys
+    EOC
+    live_stream true
+    action :nothing
   end if download_successful
 
   cron 'nextcloud' do

--- a/spec/unit/resources/osl_nextcloud_spec.rb
+++ b/spec/unit/resources/osl_nextcloud_spec.rb
@@ -351,10 +351,12 @@ describe 'nextcloud-test::default' do
             cwd: nc_wr,
             user: 'apache',
             group: 'apache',
-            command: "php occ maintenance:mode --on\nphp occ upgrade\nphp occ maintenance:mode --off\nphp occ db:add-missing-columns\nphp occ db:add-missing-indices\nphp occ db:add-missing-primary-keys\nphp occ maintenance:repair --include-expensive\n",
+            command: "php occ maintenance:mode --on\nphp occ upgrade\nphp occ maintenance:mode --on\nphp occ app:update --all\nphp occ maintenance:repair --include-expensive\nphp occ maintenance:mode --off\n",
             live_stream: true
           )
         end
+
+        it { expect(chef_run.execute('upgrade-nextcloud')).to notify('execute[nextcloud-db-add-missing]').to(:run).delayed }
 
         it do
           is_expected.to_not run_execute('nextcloud-config: trusted-domains-localhost')
@@ -444,6 +446,16 @@ describe 'nextcloud-test::default' do
         it { is_expected.to_not run_execute('nextcloud-migrate-apps-to-custom') }
 
         it do
+          is_expected.to nothing_execute('nextcloud-db-add-missing').with(
+            cwd: nc_wr,
+            user: 'apache',
+            group: 'apache',
+            command: "php occ db:add-missing-columns\nphp occ db:add-missing-indices\nphp occ db:add-missing-primary-keys\n",
+            live_stream: true
+          )
+        end
+
+        it do
           is_expected.to create_cron('nextcloud').with(
             command: '/usr/bin/php -f /var/www/nextcloud.example.com/nextcloud/cron.php',
             user: 'apache',
@@ -458,6 +470,8 @@ describe 'nextcloud-test::default' do
             command: "php occ app:install -n forms\nphp occ app:enable -n forms\n"
           )
         end
+
+        it { expect(chef_run.execute('nextcloud-app: install and enable forms')).to notify('execute[nextcloud-db-add-missing]').to(:run).delayed }
 
         it do
           is_expected.to run_execute('nextcloud-app: disable weather_status').with(
@@ -518,6 +532,16 @@ describe 'nextcloud-test::default' do
         it { is_expected.to_not run_execute('nextcloud-app: disable weather_status') }
         it { is_expected.to create_remote_file("#{nc}/config.php") }
         it { is_expected.to create_directory(nc_theming).with(owner: 'apache', group: 'apache', recursive: true) }
+
+        it do
+          is_expected.to nothing_execute('nextcloud-db-add-missing').with(
+            cwd: nc_wr,
+            user: 'apache',
+            group: 'apache',
+            command: "php occ db:add-missing-columns\nphp occ db:add-missing-indices\nphp occ db:add-missing-primary-keys\n",
+            live_stream: true
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
A major Nextcloud version bump disables third-party apps whose info.xml doesn't
yet declare compatibility with the new release. db:add-missing-indices ran
inline in the upgrade heredoc skipped those apps' tables, leaving optional
indices missing once the apps were eventually re-enabled with a compatible
release.

Split the schema fix-up commands into a separate execute resource with action
:nothing, and notify it :delayed from upgrade-nextcloud and from each per-app
install/enable execute. The resource fires only when an app's state actually
moved, preserving idempotency on quiet converges. Also add app:update --all to
the upgrade heredoc so app-store apps not listed in new_resource.apps still get
pulled forward, and re-enable maintenance mode between occ upgrade (which flips
it off) and the app-update + repair pass so users don't hit a half-updated
instance.

Fixes #16

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
