### PR TITLE
Add configurable redis/valkey port

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Installs and configures a complete Nextcloud instance. The default (and only) ac
 | `php_version` | String | `'8.3'` | PHP version to install. |
 | `php_packages` | Array | `[]` | Extra PHP packages to install beyond the defaults. |
 | `max_filesize` | String | `'1G'` | `upload_max_filesize` / `post_max_size`. |
+| `redis_port` | Integer | `6379` | Port for the Redis/Valkey `redis` config (`port`). Override when 6379 conflicts with another service. |
 | `database_host` | String (sensitive) | — | **Required.** Database host. |
 | `database_name` | String | — | **Required.** Database name. |
 | `database_user` | String (sensitive) | — | **Required.** Database user. |

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -10,6 +10,21 @@ module OSLNextcloud
         (platform_family?('rhel') && node['platform_version'].to_i >= 10) ? 'valkey' : 'redis'
       end
 
+      # Path to the redis/valkey config file, which moved between EL releases:
+      #   EL8 redis  -> /etc/redis.conf
+      #   EL9 redis  -> /etc/redis/redis.conf
+      #   EL10 valkey -> /etc/valkey/valkey.conf
+      def osl_redis_conf
+        case node['platform_version'].to_i
+        when 8
+          '/etc/redis.conf'
+        when 9
+          '/etc/redis/redis.conf'
+        else
+          '/etc/valkey/valkey.conf'
+        end
+      end
+
       # Get latest version of nextcloud from Github
       def osl_nextcloud_latest_version(version)
         releases = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,7 @@ chef_version      '>= 18.0'
 version           '3.0.0'
 
 depends          'ark'
+depends          'line'
 depends          'osl-apache'
 depends          'osl-php'
 depends          'osl-repos'

--- a/resources/osl_nextcloud.rb
+++ b/resources/osl_nextcloud.rb
@@ -30,6 +30,7 @@ property :server_name, String, name_property: true
 property :sensitive, [true, false], default: true
 property :server_aliases, Array, default: %w(localhost)
 property :max_filesize, String, default: '1G'
+property :redis_port, Integer, default: 6379
 
 default_action :create
 
@@ -303,6 +304,17 @@ action :create do
 
   package osl_redis_pkg
 
+  # The default config listens on 6379; override the `port` directive in place so we can
+  # move off it when another service already holds that port. Only this one line changes;
+  # everything else (bind, unixsocket) stays at the package default.
+  replace_or_add 'nextcloud: redis/valkey port' do
+    path osl_redis_conf
+    pattern(/^port .*/)
+    line "port #{new_resource.redis_port}"
+    sensitive false
+    notifies :restart, "service[#{osl_redis_pkg}]", :immediately
+  end
+
   service osl_redis_pkg do
     action [:enable, :start]
   end
@@ -435,9 +447,9 @@ action :create do
     user 'apache'
     command <<~EOC
       php occ config:system:set redis host --value=127.0.0.1
-      php occ config:system:set redis port --value=6379
+      php occ config:system:set redis port --value=#{new_resource.redis_port}
     EOC
-    not_if { nc_config['system']['redis'] == { 'host' => '127.0.0.1', 'port' => '6379' } }
+    not_if { nc_config['system']['redis'] == { 'host' => '127.0.0.1', 'port' => new_resource.redis_port.to_s } }
   end if download_successful
 
   execute 'nextcloud-config: mail' do

--- a/spec/unit/resources/osl_nextcloud_spec.rb
+++ b/spec/unit/resources/osl_nextcloud_spec.rb
@@ -313,10 +313,28 @@ describe 'nextcloud-test::default' do
         it { is_expected.to create_link("#{nc_v}/custom_apps").with(to: "#{nc}/custom_apps") }
 
         redis_pkg = platform[:version].to_i >= 10 ? 'valkey' : 'redis'
+        redis_conf =
+          case platform[:version].to_i
+          when 8 then '/etc/redis.conf'
+          when 9 then '/etc/redis/redis.conf'
+          else '/etc/valkey/valkey.conf'
+          end
 
         it { is_expected.to install_package(redis_pkg) }
         it { is_expected.to enable_service(redis_pkg) }
         it { is_expected.to start_service(redis_pkg) }
+
+        it do
+          is_expected.to edit_replace_or_add('nextcloud: redis/valkey port').with(
+            path: redis_conf,
+            line: 'port 6379'
+          )
+        end
+
+        it do
+          expect(chef_run.replace_or_add('nextcloud: redis/valkey port')).to \
+            notify("service[#{redis_pkg}]").to(:restart).immediately
+        end
 
         it do
           is_expected.to create_apache_app('nextcloud.example.com').with(

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -5,6 +5,12 @@ vagrant = inspec.file('/home/vagrant').exist?
 docker = inspec.file('/.dockerenv').exist?
 openstack = !vagrant and !docker
 redis_pkg = (os.family == 'redhat' && os.release.to_i >= 10) ? 'valkey' : 'redis'
+redis_conf =
+  case os.release.to_i
+  when 8 then '/etc/redis.conf'
+  when 9 then '/etc/redis/redis.conf'
+  else '/etc/valkey/valkey.conf'
+  end
 
 control 'osl_nextcloud' do
   def occ(cmd)
@@ -41,6 +47,12 @@ control 'osl_nextcloud' do
 
   describe service redis_pkg do
     it { should be_running }
+  end
+
+  # osl_nextcloud manages the `port` directive in place so it can be moved off 6379 when
+  # another service holds that port. The default recipe leaves it at 6379.
+  describe file redis_conf do
+    its('content') { should match /^port 6379$/ }
   end
 
   describe service 'httpd' do


### PR DESCRIPTION
- Add redis_port property (default 6379) for the Nextcloud occ redis config
- Manage the `port` directive in the redis/valkey config via replace_or_add,
  restarting the service on change
- Add osl_redis_conf helper for the per-EL-release config path
- Cover the new behavior in ChefSpec and InSpec

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
