### PR TITLE
Enable pretty URLs (drop /index.php/ from links)

### DIFF
--- a/resources/osl_nextcloud.rb
+++ b/resources/osl_nextcloud.rb
@@ -179,6 +179,8 @@ action :create do
     notifies :create, "link[#{nextcloud_webroot_versioned}/custom_apps]", :immediately
     notifies :create, "file[#{nextcloud_webroot}/config/apps_paths.config.php]", :immediately
     notifies :run, 'execute[upgrade-nextcloud]', :immediately
+    # Tarball ships a default .htaccess; regenerate the front-controller block after extraction.
+    notifies :run, 'execute[nextcloud-update-htaccess]', :immediately
     action :nothing
     only_if { download_successful }
   end
@@ -209,8 +211,9 @@ action :create do
     action :nothing
   end
 
+  # .htaccess included so occ maintenance:update:htaccess (run as apache) can rewrite it.
   execute 'fix-nextcloud-owner' do
-    command "chown -R apache:apache #{nextcloud_dir}/custom_apps #{nextcloud_webroot}/{apps,config}"
+    command "chown -R apache:apache #{nextcloud_dir}/custom_apps #{nextcloud_webroot}/{apps,config,.htaccess}"
     action :nothing
   end
 
@@ -519,6 +522,30 @@ action :create do
       php occ config:system:set maintenance_window_start --type=integer --value=#{new_resource.maintenance_window_start}
     EOC
     not_if { nc_config['system']['maintenance_window_start'] == new_resource.maintenance_window_start }
+  end if download_successful
+
+  # Pretty URLs: RewriteBase makes Nextcloud emit links without /index.php/. Direct
+  # /index.php/... URLs keep working (PHP path-info), so old links don't break.
+  execute 'nextcloud-config: htaccess.RewriteBase' do
+    cwd nextcloud_webroot
+    user 'apache'
+    command 'php occ config:system:set htaccess.RewriteBase --value=/'
+    notifies :run, 'execute[nextcloud-update-htaccess]', :immediately
+    not_if { nc_config['system']['htaccess.RewriteBase'] == '/' }
+  end if download_successful
+
+  # Rewrite .htaccess with the front-controller rules. Notified on RewriteBase set and on
+  # re-extraction; the front_controller_active marker keeps steady-state converges no-op.
+  execute 'nextcloud-update-htaccess' do
+    cwd nextcloud_webroot
+    user 'apache'
+    command 'php occ maintenance:update:htaccess'
+    action :nothing
+    only_if { ::File.exist?("#{nextcloud_webroot}/config/config.php") }
+    not_if do
+      htaccess = "#{nextcloud_webroot}/.htaccess"
+      ::File.exist?(htaccess) && ::File.read(htaccess).include?('front_controller_active')
+    end
   end if download_successful
 
   # One-time migration: move any user-installed (non-shipped) apps out of the versioned

--- a/spec/unit/resources/osl_nextcloud_spec.rb
+++ b/spec/unit/resources/osl_nextcloud_spec.rb
@@ -32,6 +32,7 @@ describe 'nextcloud-test::default' do
             "mail_from_address": "noreply",
             "mail_domain": "example.com",
             "maintenance_window_start": 1,
+            "htaccess.RewriteBase": "/",
             "allow_user_to_change_display_name": false,
             "log_rotate_size": 104857600,
             "overwrite.cli.url": "https://nextcloud.example.com",
@@ -293,6 +294,7 @@ describe 'nextcloud-test::default' do
         it { expect(chef_run.ruby_block('ark_notifies')).to notify("link[#{nc_v}/custom_apps]").to(:create).immediately }
         it { expect(chef_run.ruby_block('ark_notifies')).to notify("file[#{nc_wr}/config/apps_paths.config.php]").to(:create).immediately }
         it { expect(chef_run.ruby_block('ark_notifies')).to notify('execute[upgrade-nextcloud]').to(:run).immediately }
+        it { expect(chef_run.ruby_block('ark_notifies')).to notify('execute[nextcloud-update-htaccess]').to(:run).immediately }
 
         it do
           is_expected.to nothing_remote_file("#{nc_wr}/config/config.php").with(
@@ -306,7 +308,7 @@ describe 'nextcloud-test::default' do
 
         it do
           is_expected.to nothing_execute('fix-nextcloud-owner').with(
-            command: "chown -R apache:apache #{nc}/custom_apps #{nc_wr}/{apps,config}"
+            command: "chown -R apache:apache #{nc}/custom_apps #{nc_wr}/{apps,config,.htaccess}"
           )
         end
 
@@ -468,6 +470,27 @@ describe 'nextcloud-test::default' do
         end
 
         it do
+          is_expected.to run_execute('nextcloud-config: htaccess.RewriteBase').with(
+            cwd: nc_wr,
+            user: 'apache',
+            command: 'php occ config:system:set htaccess.RewriteBase --value=/'
+          )
+        end
+
+        it do
+          expect(chef_run.execute('nextcloud-config: htaccess.RewriteBase')).to \
+            notify('execute[nextcloud-update-htaccess]').to(:run).immediately
+        end
+
+        it do
+          is_expected.to nothing_execute('nextcloud-update-htaccess').with(
+            cwd: nc_wr,
+            user: 'apache',
+            command: 'php occ maintenance:update:htaccess'
+          )
+        end
+
+        it do
           is_expected.to create_file("#{nc_wr}/config/apps_paths.config.php").with(
             owner: 'apache',
             group: 'apache',
@@ -567,6 +590,7 @@ describe 'nextcloud-test::default' do
         it { is_expected.to_not run_execute('nextcloud-config: phone_region') }
         it { is_expected.to_not run_execute('nextcloud-config: overwrite.cli.url') }
         it { is_expected.to_not run_execute('nextcloud-config: maintenance_window_start') }
+        it { is_expected.to_not run_execute('nextcloud-config: htaccess.RewriteBase') }
         it { is_expected.to_not run_execute('nextcloud-config: allow_user_to_change_display_name') }
         it { is_expected.to_not run_execute('nextcloud-config: log_rotate_size') }
         it { is_expected.to_not run_execute('nextcloud-migrate-apps-to-custom') }

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -135,6 +135,27 @@ control 'osl_nextcloud' do
     its('stdout') { should match /^1$/ }
   end
 
+  # Pretty URLs: RewriteBase drives the front-controller rewrite, and
+  # maintenance:update:htaccess writes the front_controller_active marker into .htaccess.
+  # --output json escapes the slash, so the value prints as "\/".
+  describe command occ('config:system:get --output json htaccess.RewriteBase') do
+    its('stdout') { should match %r{^"\\/"$} }
+  end
+
+  describe file('/var/www/nextcloud.example.com/nextcloud/.htaccess') do
+    its('content') { should match /front_controller_active/ }
+  end
+
+  # index.php-less URLs resolve (200/30x, not 404); the login page is reachable without it.
+  describe command('curl -k -s -o /dev/null -w "%{http_code}" -H "Host: nextcloud.example.com" http://127.0.0.1/login') do
+    its('stdout') { should_not match /^404$/ }
+  end
+
+  # The legacy /index.php/ path still works too, so old links don't break.
+  describe command('curl -k -s -o /dev/null -w "%{http_code}" -H "Host: nextcloud.example.com" http://127.0.0.1/index.php/login') do
+    its('stdout') { should_not match /^404$/ }
+  end
+
   describe command occ('config:system:get --output json default_timezone') do
     its('stdout') { should match /^\"UTC\"\n$/ }
   end
@@ -187,6 +208,7 @@ control 'osl_nextcloud' do
   describe http('http://localhost', headers: { 'host' => 'nextcloud.example.com' }) do
     its('status') { should eq 302 }
     its('headers.Content-Type') { should match 'text/html' }
-    its('headers.Location') { should match 'http://nextcloud.example.com/index.php/login' }
+    # Pretty URLs: the redirect drops /index.php/.
+    its('headers.Location') { should match 'http://nextcloud.example.com/login' }
   end
 end


### PR DESCRIPTION
- Set htaccess.RewriteBase and regenerate .htaccess via maintenance:update:htaccess
- Regenerate .htaccess on every tarball extraction (ark_notifies)
- Make .htaccess apache-writable so occ can rewrite it
- Direct /index.php/... URLs still work (PHP path-info)
- Update unit and inspec tests for the new behavior

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
