### PR TITLE
Fix htaccess ownership on already-deployed instances

### DIFF
--- a/resources/osl_nextcloud.rb
+++ b/resources/osl_nextcloud.rb
@@ -524,6 +524,15 @@ action :create do
     not_if { nc_config['system']['maintenance_window_start'] == new_resource.maintenance_window_start }
   end if download_successful
 
+  # Ensure .htaccess is apache-owned every converge (not just on ark extraction) so occ can
+  # rewrite it. No content property = ownership only, existing rules untouched. Must be
+  # :create not :create_if_missing: the file already exists root-owned; we fix its owner.
+  file "#{nextcloud_webroot}/.htaccess" do
+    owner 'apache'
+    group 'apache'
+    only_if { ::Dir.exist?(nextcloud_webroot_versioned) }
+  end if download_successful
+
   # Pretty URLs: RewriteBase makes Nextcloud emit links without /index.php/. Direct
   # /index.php/... URLs keep working (PHP path-info), so old links don't break.
   execute 'nextcloud-config: htaccess.RewriteBase' do

--- a/spec/unit/resources/osl_nextcloud_spec.rb
+++ b/spec/unit/resources/osl_nextcloud_spec.rb
@@ -470,6 +470,13 @@ describe 'nextcloud-test::default' do
         end
 
         it do
+          is_expected.to create_file("#{nc_wr}/.htaccess").with(
+            owner: 'apache',
+            group: 'apache'
+          )
+        end
+
+        it do
           is_expected.to run_execute('nextcloud-config: htaccess.RewriteBase').with(
             cwd: nc_wr,
             user: 'apache',


### PR DESCRIPTION
- Ensure .htaccess is apache-owned every converge, not just on ark extraction
- Without re-extraction, fix-nextcloud-owner never ran, leaving it root-owned
  so occ maintenance:update:htaccess failed with a permissions error
- file resource has no content, so the tarball's rules are left intact

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
